### PR TITLE
Create a node module for scout-css

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,23 @@
 
 An auditing tool that helps reveal CSS dragons lurking within your stylesheets.
 
-## Get Started
+## Getting Started
+```
+npm install scout-css --save-dev
+```
+
+## Usage
+```js
+const scout = require('scout-css');
+const cssFile = 'public/css/app.min.css'
+
+scout(cssFile).then(results => {
+  // Do stuff with the results!
+});
+```
+
+
+## Development (Web app)
 
 Install all the things:
 ```

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 const getSeverity = require('./lib/getSeverity');
-return getSeverity;
+module.exports = getSeverity;

--- a/index.js
+++ b/index.js
@@ -1,25 +1,2 @@
-const express = require('express');
-const expressHandleBars = require('express-handlebars');
-
-const index = require('./routes/index');
-const parse = require('./routes/parse');
-const results = require('./routes/results');
-
-const app = express();
-
-app.engine('hbs', expressHandleBars({
-  defaultLayout: 'main',
-  extname: '.hbs',
-}));
-app.set('view engine', 'hbs');
-app.use(express.static('public'));
-
-app.use('/', index);
-app.use('/parse', parse);
-app.use('/results', results);
-
-app.listen(3000, () => {
-  console.log('http://localhost:3000/')
-});
-
-module.exports = app;
+const getSeverity = require('./lib/getSeverity');
+return getSeverity;

--- a/lib/auditor.js
+++ b/lib/auditor.js
@@ -18,7 +18,8 @@ module.exports = class Auditor {
 
   generateResults(cssData) {
     const data = cssData || this.data;
-    const results = this.scoreSelectors(this.groupSelectors(this.prepareResults(this.parseData(data))));
+    const results = this.scoreSelectors(this.groupSelectors(
+      this.prepareResults(this.parseData(data))));
     const severity = this.tallySeverity(results);
     this.results = results;
     this.severity = severity;
@@ -102,16 +103,14 @@ module.exports = class Auditor {
               selectors: [s.trim()],
               severity: Math.ceil(severity),
             };
-          } else {
-            if (!list[prime].selectors.includes(s)) {
-              list[prime].selectors.push(s);
-              // Severity algorithm?!?! Sure!
-              const severity = this.calculateSeverity(
-                list[prime].severity,
-                list[prime].selectors.length,
-                sels);
-              list[prime].severity = severity;
-            }
+          } else if (!list[prime].selectors.includes(s)) {
+            list[prime].selectors.push(s);
+            // Severity algorithm?!?! Sure!
+            const severity = this.calculateSeverity(
+              list[prime].severity,
+              list[prime].selectors.length,
+              sels);
+            list[prime].severity = severity;
           }
         }
       });
@@ -128,7 +127,8 @@ module.exports = class Auditor {
     if (selectors.some(o => o.includes('>'))) {
       multiplier = 1.25;
     }
-    const s = severity + (totalSelectors + (selectors.length * 2)) * multiplier;
+    let s = (totalSelectors + (selectors.length * 2)) * multiplier;
+    s += severity;
     return Math.ceil(s);
   }
 

--- a/lib/getCSS.js
+++ b/lib/getCSS.js
@@ -1,9 +1,9 @@
 const request = require('request');
 const getCss = require('get-css');
 
-const link = (link) => {
+const link = (ln) => {
   return new Promise((resolve, reject) => {
-    request({ url: link, timeout: 5000 }, (error, response, body) => {
+    request({ url: ln, timeout: 5000 }, (error, response, body) => {
       if (error) {
         reject(error);
       } else {
@@ -13,19 +13,15 @@ const link = (link) => {
   });
 };
 
-const url = (url) => {
+const url = (ln) => {
   return new Promise((resolve, reject) => {
-    getCss(url)
-      .then(function(response) {
-        resolve(response);
-      })
-      .catch(function(error) {
-        reject(error);
-      });
+    getCss(ln)
+      .then(response => resolve(response))
+      .catch(error => reject(error));
   });
 };
 
 module.exports = {
-  link: link,
-  url: url,
+  link,
+  url,
 };

--- a/lib/getSeverity.js
+++ b/lib/getSeverity.js
@@ -1,0 +1,28 @@
+const parse = require('./parse');
+const barista = require('seed-barista');
+
+const totalSeverityScore = (results) => {
+  return results.reduce((sum, r) => sum += r.severityScore, 0);
+};
+
+const severity = (file) => {
+  if (!file || typeof file !== 'string') {
+    return false;
+  }
+
+  const output = barista({
+    src: '/',
+    file,
+  });
+
+  return new Promise((resolve) => {
+    parse(output.css).then((results) => {
+      resolve({
+        score: totalSeverityScore(results),
+        results,
+      });
+    });
+  });
+};
+
+module.exports = severity;

--- a/lib/getSeverity.js
+++ b/lib/getSeverity.js
@@ -19,6 +19,7 @@ const severity = (file) => {
     parse(output.css).then((results) => {
       resolve({
         score: totalSeverityScore(results),
+        file,
         results,
       });
     });

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "scout-css",
   "version": "0.0.1",
   "description": "CSS auditing tool",
-  "main": "lib/getSeverity.js",
+  "main": "index.js",
   "files": [
-    "lib"
+    "lib",
+    "index.js"
   ],
   "scripts": {
     "dev": "nodemon ./server.js",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "node": ">=4"
   },
   "dependencies": {
+    "get-css": "1.2.3",
     "lodash.uniq": "4.5.0",
+    "request": "2.81.0",
     "seed-barista": "0.2.3",
     "stylelint": "7.9.0"
   },
@@ -52,13 +54,11 @@
     "express": "4.15.2",
     "express-handlebars": "3.0.0",
     "formidable": "1.1.1",
-    "get-css": "1.2.3",
     "handlebars": "4.0.6",
     "is-css": "2.0.0",
     "is-present": "1.0.0",
     "is-url": "1.2.2",
     "nodemon": "1.11.0",
-    "normalize-url": "1.9.1",
-    "request": "2.81.0"
+    "normalize-url": "1.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "scout-css",
   "version": "0.0.1",
   "description": "CSS auditing tool",
-  "main": "index.js",
+  "main": "lib/getSeverity.js",
+  "files": [
+    "lib"
+  ],
   "scripts": {
-    "dev": "nodemon ./index.js",
+    "dev": "nodemon ./server.js",
     "test": "true",
-    "start": "node index.js"
+    "start": "node server.js"
   },
   "repository": {
     "type": "git",
@@ -40,8 +43,12 @@
     "node": ">=4"
   },
   "dependencies": {
+    "lodash.uniq": "4.5.0",
+    "seed-barista": "0.2.3",
+    "stylelint": "7.9.0"
+  },
+  "devDependencies": {
     "body-parser": "1.17.1",
-    "csslint": "1.0.5",
     "express": "4.15.2",
     "express-handlebars": "3.0.0",
     "formidable": "1.1.1",
@@ -50,13 +57,8 @@
     "is-css": "2.0.0",
     "is-present": "1.0.0",
     "is-url": "1.2.2",
-    "lodash.uniq": "4.5.0",
+    "nodemon": "1.11.0",
     "normalize-url": "1.9.1",
-    "request": "2.81.0",
-    "seed-barista": "0.2.3",
-    "stylelint": "7.9.0"
-  },
-  "devDependencies": {
-    "nodemon": "1.11.0"
+    "request": "2.81.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,25 @@
+// const express = require('express');
+// const expressHandleBars = require('express-handlebars');
+
+// const index = require('./routes/index');
+// const parse = require('./routes/parse');
+// const results = require('./routes/results');
+
+// const app = express();
+
+// app.engine('hbs', expressHandleBars({
+//   defaultLayout: 'main',
+//   extname: '.hbs',
+// }));
+// app.set('view engine', 'hbs');
+// app.use(express.static('public'));
+
+// app.use('/', index);
+// app.use('/parse', parse);
+// app.use('/results', results);
+
+// app.listen(3000, () => {
+//   console.log('http://localhost:3000/')
+// });
+
+// module.exports = app;

--- a/server.js
+++ b/server.js
@@ -1,25 +1,25 @@
-// const express = require('express');
-// const expressHandleBars = require('express-handlebars');
+const express = require('express');
+const expressHandleBars = require('express-handlebars');
 
-// const index = require('./routes/index');
-// const parse = require('./routes/parse');
-// const results = require('./routes/results');
+const index = require('./routes/index');
+const parse = require('./routes/parse');
+const results = require('./routes/results');
 
-// const app = express();
+const app = express();
 
-// app.engine('hbs', expressHandleBars({
-//   defaultLayout: 'main',
-//   extname: '.hbs',
-// }));
-// app.set('view engine', 'hbs');
-// app.use(express.static('public'));
+app.engine('hbs', expressHandleBars({
+  defaultLayout: 'main',
+  extname: '.hbs',
+}));
+app.set('view engine', 'hbs');
+app.use(express.static('public'));
 
-// app.use('/', index);
-// app.use('/parse', parse);
-// app.use('/results', results);
+app.use('/', index);
+app.use('/parse', parse);
+app.use('/results', results);
 
-// app.listen(3000, () => {
-//   console.log('http://localhost:3000/')
-// });
+app.listen(3000, () => {
+  console.log('http://localhost:3000/')
+});
 
-// module.exports = app;
+module.exports = app;

--- a/test.js
+++ b/test.js
@@ -1,0 +1,14 @@
+const getSeverity = require('./lib/getSeverity');
+
+getSeverity('public/styles/hs-app.css').then(results => {
+  const threshold = 200000;
+  if (results.score > threshold) {
+    console.log('Regression');
+    console.log('  🔥 CSS has gotten worse!!!');
+  } else {
+    console.log('CSS is fine…');
+  }
+  console.log('Severity:');
+  console.log('  Threshold:', threshold);
+  console.log('  Score:', results.score);
+});

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 const getSeverity = require('./lib/getSeverity');
 
+console.log('');
 const message = (results, threshold) => {
   console.log(`Tested: ${results.file}`);
   if (results.score > threshold) {
@@ -10,8 +11,8 @@ const message = (results, threshold) => {
     console.log('  CSS has not gotten worse');
   }
   console.log('Severity:');
-  console.log('  Threshold:', threshold);
-  console.log('  Score:', results.score);
+  console.log('  Threshold:', threshold.toLocaleString());
+  console.log('      Score:', results.score.toLocaleString());
   console.log('');
 };
 

--- a/test.js
+++ b/test.js
@@ -1,14 +1,26 @@
 const getSeverity = require('./lib/getSeverity');
+const threshold = 200000;
 
-getSeverity('public/styles/hs-app.css').then(results => {
-  const threshold = 200000;
+const message = (results) => {
+  let threshold = 3000;
+  console.log(`Tested: ${results.file}`);
   if (results.score > threshold) {
-    console.log('Regression');
-    console.log('  🔥 CSS has gotten worse!!!');
+    console.log('🔥 Regression');
+    console.log('  🔥 CSS has gotten worse!!! OMG!!! 🔥');
   } else {
-    console.log('CSS is fine…');
+    console.log('⚡️ No Regression');
+    console.log('  CSS has not gotten worse');
   }
   console.log('Severity:');
   console.log('  Threshold:', threshold);
   console.log('  Score:', results.score);
+  console.log('');
+};
+
+getSeverity('public/css/seed-framework.min.css').then(results => {
+  message(results);
+});
+
+getSeverity('public/styles/hs-app.css').then(results => {
+  message(results);
 });

--- a/test.js
+++ b/test.js
@@ -1,8 +1,6 @@
 const getSeverity = require('./lib/getSeverity');
-const threshold = 200000;
 
-const message = (results) => {
-  let threshold = 3000;
+const message = (results, threshold) => {
   console.log(`Tested: ${results.file}`);
   if (results.score > threshold) {
     console.log('🔥 Regression');
@@ -18,9 +16,9 @@ const message = (results) => {
 };
 
 getSeverity('public/css/seed-framework.min.css').then(results => {
-  message(results);
+  message(results, 3000);
 });
 
 getSeverity('public/styles/hs-app.css').then(results => {
-  message(results);
+  message(results, 200000);
 });


### PR DESCRIPTION
Allows folks to `npm install --save-dev scout-css` and use it for tests, like:

```js
const scout = require('scout-css');
const cssFile = 'public/css/app.min.css'

scout(cssFile).then(results => {
  // Do stuff with the results!
});
```